### PR TITLE
start fetchData interval when refresh page

### DIFF
--- a/src/lib/auth-vue-http.ts
+++ b/src/lib/auth-vue-http.ts
@@ -125,6 +125,11 @@ export default class AuthVueHttp {
   }
 
   private configureHttp() {
+    const token = this.storeManager.getToken();
+    if (!!token) {
+      this.startIntervals();
+    }
+
     this.http.interceptors.request.use((request: AxiosRequestConfig) => {
       if (request.headers) {
         Object.keys(request.headers)


### PR DESCRIPTION
Fixes #172 

On AuthVueHttp.configureHttp,
Checking token is exist, then call AuthVueHttp.startIntervals.
To Fix FetchData intervals not restart when user refresh page.