### PR TITLE
Synchronize state with vuex mutations from outside

### DIFF
--- a/src/lib/auth-vue-store-manager.ts
+++ b/src/lib/auth-vue-store-manager.ts
@@ -62,26 +62,26 @@ export default class AuthStoreManager extends VueAuthStore {
   }
 
   public setToken(token: string | null): void {
+    this.options.Vue.$data.token = token;
     this.allStores
       .forEach((store) => {
         store.setToken(token);
       });
-    this.options.Vue.$data.token = token;
   }
 
   public setUser(user: AuthUser | null): void {
+    this.options.Vue.$data.user = user;
     this.allStores
       .forEach((store) => {
         store.setUser(user);
       });
-    this.options.Vue.$data.user = user;
   }
 
   public resetAll(): void {
-    this.setUser(null);
-    this.setToken(null);
     this.options.Vue.$data.user = null;
     this.options.Vue.$data.token = null;
+    this.setUser(null);
+    this.setToken(null);
   }
 
   public check(role?: string | string[]): boolean {

--- a/src/lib/store/store-vuex.ts
+++ b/src/lib/store/store-vuex.ts
@@ -84,10 +84,10 @@ export default class StoreVuex extends VueAuthStore {
     this.store.subscribe((mutation: any, state: any) => {
       if (mutation.type === `${this.module}/SET_TOKEN`
         && mutation.payload !== this.options.Vue.$data.token) {
-        this.options.Vue.$data.token = mutation.payload
+        this.options.Vue.$data.token = mutation.payload;
       } else if (mutation.type === `${this.module}/SET_USER`
         && mutation.payload !== this.options.Vue.$data.user) {
-        this.options.Vue.$data.user = mutation.payload
+        this.options.Vue.$data.user = mutation.payload;
       }
     });
   }

--- a/src/lib/store/store-vuex.ts
+++ b/src/lib/store/store-vuex.ts
@@ -80,5 +80,15 @@ export default class StoreVuex extends VueAuthStore {
     };
 
     this.store.registerModule(this.module, module);
+    // Listen for mutation from outside, e.g. with vuex-shared-mutations
+    this.store.subscribe((mutation: any, state: any) => {
+      if (mutation.type === `${this.module}/SET_TOKEN`
+        && mutation.payload !== this.options.Vue.$data.token) {
+        this.options.Vue.$data.token = mutation.payload
+      } else if (mutation.type === `${this.module}/SET_USER`
+        && mutation.payload !== this.options.Vue.$data.user) {
+        this.options.Vue.$data.user = mutation.payload
+      }
+    });
   }
 }


### PR DESCRIPTION
If using vuex-shared-mutations, the vuex token/user can be changed but the internal state will be inconsistent.

This PR needs extended review, because I'm clearly not sure if it fits inside the current code architecture.

Maybe some listeners should also be added to session/local storage and cookies.