### PR TITLE
Declare promise instead of initialization

### DIFF
--- a/src/lib/auth-vue-router.ts
+++ b/src/lib/auth-vue-router.ts
@@ -21,7 +21,7 @@ export default class AuthVueRouter {
   }
 
   public afterLogin(redirect: RawLocation | string | undefined) {
-    let promise = Promise.resolve(redirect);
+    let promise!: Promise<Route>;
     if (redirect) {
       promise = this.router.push(redirect);
     } else if (this.router.currentRoute.query.nextUrl) {


### PR DESCRIPTION
It seems that the first initialization of `promise` is never used. And its type is different, so let's declare it with the correct type from the beginning.