### PR TITLE
Use synchronous interceptors

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@vue/cli-plugin-vuex": "4.5.13",
     "@vue/cli-service": "4.5.13",
     "@vue/test-utils": "1.2.2",
-    "axios": "0.21.1",
+    "axios": "0.21.4",
     "axios-mock-adapter": "1.20.0",
     "babel-core": "7.0.0-bridge.0",
     "codacy-coverage": "3.4.0",

--- a/src/lib/auth-vue-http.ts
+++ b/src/lib/auth-vue-http.ts
@@ -179,7 +179,7 @@ export default class AuthVueHttp {
       return request;
     }, (error: any) => {
       return Promise.reject(error);
-    });
+    }, { synchronous: true });
     this.http.interceptors.response.use((response: AxiosResponse) => {
       return response;
     }, (error: any) => {
@@ -188,7 +188,7 @@ export default class AuthVueHttp {
         this.logout();
       }
       return Promise.reject(error);
-    });
+    }, { synchronous: true });
   }
 
   private startIntervals() {


### PR DESCRIPTION
Since https://github.com/axios/axios/pull/2702 (in axios 0.21.2) it is possible to avoid delay in requests.
Interceptors set up by vue-auth are global, and are delaying every other callers.